### PR TITLE
fix #56: Add duplication check on allcomp.const model traversal.

### DIFF
--- a/query/extensions/allcomp/const.go
+++ b/query/extensions/allcomp/const.go
@@ -17,7 +17,7 @@ type Const struct {
 	LeafValue bool
 }
 
-// Encoding returns a CNF that is true if and only if the query constan ac.I
+// Encoding returns a CNF that is true if and only if the query constant ac.I
 // is such that all its completions are evaluated as ac.LeafValue by the model.
 func (ac Const) Encoding(ctx query.QContext) (cnf.CNF, error) {
 	if ctx == nil {
@@ -36,6 +36,7 @@ func (ac Const) Encoding(ctx query.QContext) (cnf.CNF, error) {
 
 	var n query.Node
 	dim := ctx.Dim()
+	nvisited := make(map[int]struct{})
 	nstack := []query.Node{nodes[0]}
 
 	for len(nstack) > 0 {
@@ -58,11 +59,24 @@ func (ac Const) Encoding(ctx query.QContext) (cnf.CNF, error) {
 
 		switch sc.Val[n.Feat] {
 		case query.BOT:
-			nstack = append(nstack, nodes[n.ZChild], nodes[n.OChild])
+			if _, ok := nvisited[n.ZChild]; !ok {
+				nvisited[n.ZChild] = struct{}{}
+				nstack = append(nstack, nodes[n.ZChild])
+			}
+			if _, ok := nvisited[n.OChild]; !ok {
+				nvisited[n.OChild] = struct{}{}
+				nstack = append(nstack, nodes[n.OChild])
+			}
 		case query.ZERO:
-			nstack = append(nstack, nodes[n.ZChild])
+			if _, ok := nvisited[n.ZChild]; !ok {
+				nvisited[n.ZChild] = struct{}{}
+				nstack = append(nstack, nodes[n.ZChild])
+			}
 		case query.ONE:
-			nstack = append(nstack, nodes[n.OChild])
+			if _, ok := nvisited[n.OChild]; !ok {
+				nvisited[n.OChild] = struct{}{}
+				nstack = append(nstack, nodes[n.OChild])
+			}
 		}
 	}
 

--- a/query/extensions/allcomp/const_test.go
+++ b/query/extensions/allcomp/const_test.go
@@ -84,7 +84,7 @@ func TestConst_Encoding_AllNeg(t *testing.T) {
 	}
 }
 
-func TestConst_Encoding_AllNeg_Guraded(t *testing.T) {
+func TestConst_Encoding_AllNeg_Guarded(t *testing.T) {
 	for i, tc := range AllNegPTT {
 		t.Run(tc.Name, func(t *testing.T) {
 			runGuardedAllCompConst(t, i, tc, false, false)
@@ -106,7 +106,7 @@ func TestNotConst_Encoding_AllNeg(t *testing.T) {
 	}
 }
 
-func TestNotConst_Encoding_AllNeg_Guraded(t *testing.T) {
+func TestNotConst_Encoding_AllNeg_Guarded(t *testing.T) {
 	for i, tc := range AllNegNTT {
 		t.Run(tc.Name, func(t *testing.T) {
 			runGuardedAllCompConst(t, i, tc, false, true)


### PR DESCRIPTION
Add map to check if a node has been visited on a previous loop of the traversal.